### PR TITLE
Fix bug with locking/unlocking tokens

### DIFF
--- a/src/chexchexchex.cpp
+++ b/src/chexchexchex.cpp
@@ -192,7 +192,7 @@ void token::chintailock(name owner, asset quantity, uint8_t days)
   auto itr = locked.begin();
   while (itr != locked.end())
   {
-    locked.erase(itr);
+    itr = locked.erase(itr);
   }
   locked.emplace(owner, [&](auto & entry)
       {

--- a/src/chexchexchex.cpp
+++ b/src/chexchexchex.cpp
@@ -194,7 +194,7 @@ void token::chintailock(name owner, asset quantity, uint8_t days)
   {
     itr = locked.erase(itr);
   }
-  locked.emplace(owner, [&](auto & entry)
+  locked.emplace(_self, [&](auto & entry)
       {
       entry.lock_time = days;
       entry.quantity = quantity;

--- a/src/chexchexchex.cpp
+++ b/src/chexchexchex.cpp
@@ -189,22 +189,16 @@ void token::chintailock(name owner, asset quantity, uint8_t days)
   check(days > 0, "You can not lock tokens for less than 1 day");
 
   locked_funds locked( _self, owner.value );
-  auto itr = locked.find(days);
-  if(itr == locked.end())
+  auto itr = locked.begin();
+  while (itr != locked.end())
   {
-    locked.emplace(owner, [&](auto & entry)
-        {
-        entry.lock_time = days;
-        entry.quantity = quantity;
-        });
+    locked.erase(itr);
   }
-  else
-  {
-    locked.modify(itr, owner, [&](auto & entry)
-        {
-        entry.quantity += quantity;
-        });
-  }
+  locked.emplace(owner, [&](auto & entry)
+      {
+      entry.lock_time = days;
+      entry.quantity = quantity;
+      });
 }
 
 void token::unlock( name owner, asset quantity )

--- a/src/chexchexchex.cpp
+++ b/src/chexchexchex.cpp
@@ -254,7 +254,6 @@ void token::unlock( name owner, asset quantity )
 void token::convert_locked_to_balance( name owner )
 {
   accounts from_acnts( _self, owner.value );
-  locked_funds locked( _self, owner.value );
   unlocking_funds unlocking( _self, owner.value );
   
   auto itr = unlocking.begin();
@@ -265,11 +264,11 @@ void token::convert_locked_to_balance( name owner )
       ++itr;
       continue;
     }
-    auto acnt_itr = from_acnts.find(itr->quantity.symbol.code().raw());
+    auto acnt_itr = from_acnts.begin();
     check( acnt_itr->locked >= itr->quantity, "Trying to claim more tokens from unlocking than are available in your locked balance. Please contact a member of the Chintai team on Telegram (https://t.me/ChintaiEOS) or by email (hello@chintai.io)." );
     from_acnts.modify(acnt_itr, same_payer, [&](auto & entry)
         {
-        entry.locked -= itr->quantity;
+        entry.locked.amount -= itr->quantity.amount;
         });
     itr = unlocking.erase(itr);
   }

--- a/src/chexchexchex.cpp
+++ b/src/chexchexchex.cpp
@@ -186,7 +186,7 @@ void token::chintailock(name owner, asset quantity, uint8_t days)
   check(quantity.amount > 0, "Can not lock a negative amount");
   check(acnt_itr->locked >= quantity, "Not enough unlocked funds available to create a locked entry for, the maximum possible quantityis " + (acnt_itr->locked).to_string());
   check(days <= 100, "You can not lock tokens for more than 100 days");
-  check(days > 0, "You can not lock tokens for less than 1 day");
+  check(days >= 0, "You can not lock tokens for less than 0 days");
 
   locked_funds locked( _self, owner.value );
   auto itr = locked.begin();


### PR DESCRIPTION
## Issue

- When calling the lock function, a previous instance of the accounts table was used before the `convert_locked_to_balance()` function was called, which caused the code to not observe the changes to the locked quantity that was made inside this function.

## Changes

- Update the logic within `chintailock` action, deleting all previous locked table entries and overwriting them with one new table entry.

