### PR TITLE
Add sorted accounts table, and ability to copy data over

### DIFF
--- a/include/chexchexchex.hpp
+++ b/include/chexchexchex.hpp
@@ -57,6 +57,9 @@ namespace chex{
          [[eosio::action]]
          void burn( name owner, asset quantity );
 
+         [[eosio::action]]
+         void copyaccounts( name const &owner, symbol const &symbol);
+
          void convert_locked_to_balance( name owner );
 
          static asset get_supply( name token_contract_account, symbol_code sym_code )
@@ -107,6 +110,13 @@ namespace chex{
             uint64_t primary_key()const { return balance.symbol.code().raw(); }
          };
 
+         struct [[eosio::table]] sortedaccnts {
+            asset    balance;
+            uint64_t primary_key()const { return balance.symbol.code().raw(); }
+
+            uint64_t balance_index() const { return balance.amount; }
+         };
+
          struct [[eosio::table]] currency_stats {
             asset    supply;
             asset    max_supply;
@@ -132,6 +142,9 @@ namespace chex{
          typedef eosio::multi_index< "stat"_n, currency_stats > stats;
          typedef eosio::multi_index< "locked"_n, locked_fund > locked_funds;
          typedef eosio::multi_index< "unlocking"_n, unlocking_fund > unlocking_funds;
+         typedef eosio::multi_index< "sortedaccnts"_n, sortedaccnts,
+           eosio::indexed_by< "byamount"_n, eosio::const_mem_fun< sortedaccnts, uint64_t, &sortedaccnts::balance_index
+             > > > sorted_accounts;
 
          void sub_balance( name owner, asset value );
          void add_balance( name owner, asset value, name ram_payer );

--- a/src/chexchexchex.cpp
+++ b/src/chexchexchex.cpp
@@ -284,6 +284,11 @@ void token::sub_balance( name owner, asset value ) {
    check( from.balance - from.locked >= value, "You are attempting to transfer " + value.to_string() + ", but you can only transfer " + (from.balance - from.locked).to_string() + ", because " + from.locked.to_string() + " are in the locked state. You can unlock them using the \"unlock\" action. You must then wait for the tokens to finish unlocking before attempting this action again." );
    auto sorted_accounts_entry = sorted.find( value.symbol.code().raw() );
 
+   if(sorted_accounts_entry == sorted.end())
+   {
+     copyaccounts(owner, value.symbol);
+   }
+
    from_acnts.modify( from, owner, [&]( auto& a ) {
          a.balance -= value;
       });
@@ -311,6 +316,10 @@ void token::add_balance( name owner, asset value, name ram_payer )
       to_acnts.modify( to, same_payer, [&]( auto& a ) {
         a.balance += value;
       });
+      if(sorted_accounts_entry == sorted.end())
+         {
+           copyaccounts(owner, value.symbol);
+         }
       sorted.modify( sorted_accounts_entry, same_payer, [&]( auto& a ) {
           a.balance += value;
       });


### PR DESCRIPTION
## Changes

- Add sorted accounts table, which will allow the balances to be sorted by amount.
- Add action to copy data from regular accounts table to sorted accounts table.

- These changes are to ease the ability to sort wallets on the eos mainnet by amount of tokens held, and allow us to deliver metrics of how many wallets own chex, how many have above X amount, etc. These metrics are desirable from exchanges and other professional entities and individuals.
